### PR TITLE
Bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/check_cdns.yaml
+++ b/.github/workflows/check_cdns.yaml
@@ -9,5 +9,5 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v5
     - run: ./_action_files/check_js.sh

--- a/.github/workflows/check_config.yaml
+++ b/.github/workflows/check_config.yaml
@@ -5,10 +5,10 @@ jobs:
  check-config:
    runs-on: ubuntu-latest
    steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 
@@ -39,13 +39,13 @@ jobs:
 
     - name: Create issue if baseurl rule is violated
       if: steps.baseurl.outcome == 'failure'
-      uses: actions/github-script@0.6.0
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           var err = process.env.ERROR_STRING;
           var run_id = process.env.RUN_ID;
-          github.issues.create({
+          github.rest.issues.create({
             owner: context.repo.owner,
             repo: context.repo.repo,
             title: "Error with repository configuration: baseurl",
@@ -66,11 +66,11 @@ jobs:
 
     - name: Create Issue if User Pages rule is violated
       if: steps.userpage.outcome == 'failure'
-      uses: actions/github-script@0.6.0
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.create({
+          github.rest.issues.create({
             owner: context.repo.owner,
             repo: context.repo.repo,
             title: "Error with repository configuration: repo name",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           
 
     - name: Copy Repository Contents
-      uses: actions/checkout@main
+      uses: actions/checkout@v5
       with:
         persist-credentials: false
 
@@ -52,7 +52,7 @@ jobs:
 
     - name: Deploy
       if: github.event_name == 'push'
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         deploy_key: ${{ secrets.SSH_DEPLOY_KEY }}
         publish_dir: ./_site

--- a/.github/workflows/issue_reminder.yaml
+++ b/.github/workflows/issue_reminder.yaml
@@ -12,13 +12,13 @@ jobs:
     steps:
 
     - name: Comment on issue
-      uses: actions/github-script@0.6.0
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           var url = 'https://github.com/fastai/fastpages/blob/master/_fastpages_docs/TROUBLESHOOTING.md'
           var msg = `Thank you for opening an issue.  If this issue is related to a bug, please follow the steps and provide the information outlined in the [Troubleshooting Guide](${url}).  Failure to follow these instructions may result in automatic closing of this issue.`
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -8,12 +8,12 @@ jobs:
     steps:
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v6
       with:
         python-version: 3.6
 
     - name: Copy Repository Contents
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
         
     - name: modify files
       run: |
@@ -84,13 +84,13 @@ jobs:
         GH_USERNAME: ${{ github.event.commits[0].author.username }}
 
     - name: Open a PR
-      uses: actions/github-script@0.5.0
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           var fs = require('fs');
           var contents = fs.readFileSync('_fastpages_docs/_setup_pr_template.md', 'utf8');
-          github.pulls.create({
+          github.rest.pulls.create({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         title: 'Initial Setup',

--- a/.github/workflows/upgrade.yaml
+++ b/.github/workflows/upgrade.yaml
@@ -24,20 +24,20 @@ jobs:
         (github.event.issue.author_association != 'OWNER') && 
         (github.event.issue.author_association != 'COLLABORATOR') &&
         (github.event.issue.author_association != 'MEMBER')
-      uses: actions/github-script@0.6.0
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           var permission_level = process.env.permission_level;
           var url = 'https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/permission-levels-for-a-user-account-repository#collaborator-access-on-a-repository-owned-by-a-user-account'
           var msg = `You must have the [permission level](${url}) of either an **OWNER**, **COLLABORATOR** or **MEMBER** to instantiate an upgrade request.  Your permission level is ${permission_level}`
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: msg
           })
-          github.issues.update({
+          github.rest.issues.update({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -57,19 +57,19 @@ jobs:
     steps:
     
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v6
       with:
         python-version: 3.7
-    
+
     - name: checkout latest fastpages
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
         repository: 'fastai/fastpages'
         path: 'new_files'
         persist-credentials: false
-        
+
     - name: copy this repo's contents
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
       with:
         path: 'current_files'
         persist-credentials: false
@@ -170,7 +170,7 @@ jobs:
         upgrade_pr_path.write_text(upgrade_pr)
       shell: python
 
-    - uses: webfactory/ssh-agent@v0.4.1
+    - uses: webfactory/ssh-agent@v0.10.0
       if: steps.check_version.outputs.vbump == 'true'
       with:
           ssh-private-key: ${{ secrets.SSH_DEPLOY_KEY }}
@@ -196,13 +196,13 @@ jobs:
     - name: Open a PR
       if: steps.check_version.outputs.vbump == 'true'
       id: pr
-      uses: actions/github-script@0.6.0
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           var fs = require('fs');
           var contents = fs.readFileSync('current_files/_fastpages_docs/_upgrade_pr.md', 'utf8');
-          github.pulls.create({
+          github.rest.pulls.create({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         title: '[fastpages] Update repo with changes from fastpages',
@@ -214,13 +214,13 @@ jobs:
   
     - name: Comment on issue if failure
       if: failure()  && (steps.check_version.outputs.vbump == 'true')
-      uses: actions/github-script@0.6.0
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           var pr_num = process.env.PR_NUM;
           var repo = process.env.REPO
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -232,13 +232,13 @@ jobs:
 
     - name: Comment on issue 
       if: steps.check_version.outputs.vbump == 'true'    
-      uses: actions/github-script@0.6.0
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           var pr_num = process.env.PR_NUM;
           var repo = process.env.REPO
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -250,11 +250,11 @@ jobs:
 
     - name: Comment on issue if version has not changed
       if: steps.check_version.outputs.vbump == 'false'    
-      uses: actions/github-script@0.6.0
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -263,11 +263,11 @@ jobs:
           
     - name: Close Issue
       if: always()
-      uses: actions/github-script@0.6.0
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          github.issues.update({
+          github.rest.issues.update({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
## Summary
- Bumps all JavaScript-based actions to their Node 24 major:
  - `actions/checkout` → `v5`
  - `actions/setup-python` → `v6`
  - `actions/github-script` → `v8`
  - `peaceiris/actions-gh-pages` → `v4`
  - `webfactory/ssh-agent` → `v0.10.0`
- Migrates inline `github-script` calls from `github.issues.*` / `github.pulls.*` to `github.rest.*` (required from `github-script@v5` onward).
- Also replaces the previously unpinned `actions/checkout@main` (in `ci.yaml` and `check_cdns.yaml`) with a pinned major.

Jekyll build is unaffected — it runs inside `docker://fastai/fastpages-jekyll`, so the runner's Node version is irrelevant to the site build.

## Test plan
- [ ] CI workflow (`ci.yaml`) passes on this PR
- [ ] `check_config.yaml` runs on push and completes without deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)