### PR TITLE
Pin connection_pool < 3.0 and update to 2.5.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "public_suffix", "~> 5.1" # 6.0 requires ruby >= 3.0
 gem "ffi", "~> 1.16.3" # 1.17 incompatible with github actions
 gem "nokogiri", "~> 1.15.6" # 1.16 requires ruby >= 3.0
 gem "activesupport", "~> 7.1.5" # 7.2 requires ruby >= 3.1
+gem "connection_pool", "< 3.0"
 gem "securerandom", "~> 0.3.2" # 0.4.0 requires ruby >= 3.1.0
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     bigdecimal (3.2.2)
     colorator (1.1.0)
     concurrent-ruby (1.3.7)
-    connection_pool (2.5.3)
+    connection_pool (2.5.5)
     drb (2.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -152,6 +152,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 7.1.5)
+  connection_pool (< 3.0)
   faraday (~> 2.8.1)
   ffi (~> 1.16.3)
   jekyll (~> 4.1.1)


### PR DESCRIPTION
## Summary
- Adds `gem "connection_pool", "< 3.0"` constraint to `Gemfile`
- Bumps `connection_pool` 2.5.3 → 2.5.5 (latest 2.x)

## Test plan
- [ ] CI (`build-site`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)